### PR TITLE
Update hasBlock references to (has-block) to resolve deprecation warnings

### DIFF
--- a/addon/templates/components/one-way-select.hbs
+++ b/addon/templates/components/one-way-select.hbs
@@ -9,7 +9,7 @@
   {{#each this.optionGroups as |optionGroup groupIndex|}}
     <optgroup label={{optionGroup.groupName}}>
       {{#each optionGroup.options as |option index|}}
-        {{#if hasBlock}}
+        {{#if (has-block)}}
           <OneWaySelect::option
             @selected={{this.selectedValue}}
             @option={{option}}
@@ -33,7 +33,7 @@
   {{/each}}
 {{else}}
   {{#each this.options as |option index|}}
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       <OneWaySelect::Option
           @selected={{this.selectedValue}}
           @option={{@option}}

--- a/addon/templates/components/one-way-select/option.hbs
+++ b/addon/templates/components/one-way-select/option.hbs
@@ -1,6 +1,6 @@
 <option value={{if @optionValuePath (get @option @optionValuePath) @option}}
         selected={{one-way-select/contains @selected @option @optionValuePath @optionTargetPath}}>
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield}}
   {{else if @optionComponent}}
     {{component @optionComponent


### PR DESCRIPTION
This is our own vendorised fix for this PR: https://github.com/DockYard/ember-one-way-select/pull/21